### PR TITLE
[Doc] Fix issue with parentheses in URL.

### DIFF
--- a/manual/graphics/graphics-reference/effects-and-shaders-reference/shading-language/index.md
+++ b/manual/graphics/graphics-reference/effects-and-shaders-reference/shading-language/index.md
@@ -2,7 +2,7 @@
 
 # Introduction
 
-Xenko is providing a *superset* of the [HLSL Shading language](http://msdn.microsoft.com/en-us/library/windows/desktop/bb509561(v=vs.85).aspx) , bringing advanced and higher level language constructions. This language enhances the developer experience while authoring shaders with:
+Xenko is providing a *superset* of the [HLSL Shading language](http://msdn.microsoft.com/en-us/library/windows/desktop/bb509561%28v=vs.85%29.aspx) , bringing advanced and higher level language constructions. This language enhances the developer experience while authoring shaders with:
 
 - **Extensibility** to allow shaders to be extended easily using Object-Oriented-Programming concepts like class, inheritance, composition.
 - **Modularity** to provide a set modular shaders each focusing on a single rendering technique, more easily manageable

--- a/manual/ui/index.md
+++ b/manual/ui/index.md
@@ -2,7 +2,7 @@
 
 Xenko contains a complete UI system to build visually impressive in-game UI interfaces.
 
-It is built upon a simplified design of [Windows Presentation Foundation (WPF)](http://msdn.microsoft.com/en-us/library/ms754130(v=vs.110).aspx)  so that people can get quickly up to speed.
+It is built upon a simplified design of [Windows Presentation Foundation (WPF)](http://msdn.microsoft.com/en-us/library/ms754130%28v=vs.110%29.aspx)  so that people can get quickly up to speed.
 
 Many of the usual components and containers are all here, and on top of that it supports both 2D and 3D in a resolution-independent way.
 

--- a/manual/ui/layout-system.md
+++ b/manual/ui/layout-system.md
@@ -2,7 +2,7 @@
 
 In Xenko, Layout System is very similar to the one in WPF.
 
-You can find a much more detailed explanation in [WPF Layout System documentation](http://msdn.microsoft.com/en-us/library/ms745058(v=vs.110).aspx) .
+You can find a much more detailed explanation in [WPF Layout System documentation](http://msdn.microsoft.com/en-us/library/ms745058%28v=vs.100%29.aspx) .
 
 # Introduction
 


### PR DESCRIPTION
URL containing parentheses or not processed correctly in the online documentation, although they appear to be when displayed in GitHub. As a fix, I used the corresponding HTML encoding.

In the future, it might be better to fix the markdown processor used in the online documentation.