### PR TITLE
Tweaked code example in Virtual Buttons.

### DIFF
--- a/manual/input/virtual-buttons.md
+++ b/manual/input/virtual-buttons.md
@@ -24,16 +24,27 @@ For example, imagine you develop a first-person shooter game and need to assign 
 public override void Start()
 {
     base.Start();
-    //Bind "M" key to a virtual button "MyButton".
-    VirtualButtonBinding b = new VirtualButtonBinding("MyButton", VirtualButton.Keyboard.M);
+
+    // Create a new VirtualButtonConfigSet if none exists. 
+    Input.VirtualButtonConfigSet = Input.VirtualButtonConfigSet ?? new VirtualButtonConfigSet();
+    
+    //Bind "M" key, GamePad "Start" button and left mouse button to a virtual button "MyButton".
+    VirtualButtonBinding b1 = new VirtualButtonBinding("MyButton", VirtualButton.Keyboard.M);
+    VirtualButtonBinding b2 = new VirtualButtonBinding("MyButton", VirtualButton.GamePad.Start);
+    VirtualButtonBinding b3 = new VirtualButtonBinding("MyButton", VirtualButton.Mouse.Left);
 
     VirtualButtonConfig c = new VirtualButtonConfig();
 
-    c.Add(b);
+    c.Add(b1);
+    c.Add(b2);
+    c.Add(b3);
 
     Input.VirtualButtonConfigSet.Add(c);
-   
-    float button = Input.GetVirtualButton(1, "MyButton");
+}
+
+public override void Update() {
+    float button = Input.GetVirtualButton(0, "MyButton");
+}
 ```
 
 > [!Note]


### PR DESCRIPTION
Hi!

While reading the Virtual Buttons sections I've noticed two minor issues with the example code:

- ```Input.VirtualButtonConfigSet``` is ```null``` by default, so ```Input.VirtualButtonConfigSet.Add(c);``` will cause a ```NullReferenceException``` (which may be by design, but it's not very clear from the documentation).
- ```float button = Input.GetVirtualButton(1, "MyButton");``` will always be 0, unless you add a second ```VirtualButtonConfig```.

I've added a null-check for VirtualButtonConfigSet, changed the ```Input.GetVirtualButton(1, "MyButton");``` to ```Input.GetVirtualButton(0, "MyButton");```, added a couple of VirtualButtonBindings and moved the last call to an Update method, since you generally never would want to do that in a Start method.