### PR TITLE
Fix link to Render stages

### DIFF
--- a/manual/graphics/rendering-pipeline/index.md
+++ b/manual/graphics/rendering-pipeline/index.md
@@ -31,4 +31,4 @@ For more information, see [Render stages](render-stages.md).
 ## In this section
 
 * [Render features](render-features.md)
-* [Render stages](render-features.md)
+* [Render stages](render-stages.md)

--- a/manual/toc.md
+++ b/manual/toc.md
@@ -135,6 +135,7 @@
 ### [Light streaks](graphics/post-effects/light-streaks.md)
 ## [Rendering pipeline](graphics/rendering-pipeline/index.md)
 ### [Render features](graphics/rendering-pipeline/render-features.md)
+### [Render stages](graphics/rendering-pipeline/render-stages.md)
 ## [Sprite fonts](graphics/sprite-fonts.md)
 ## [Skyboxes](graphics/skyboxes.md)
 


### PR DESCRIPTION
I have noticed that a link to Render stages is using a wrong url  to render-features.md (possible copypaste) and it was missing from toc.